### PR TITLE
fix flit payment redirect

### DIFF
--- a/src/controllers/balanceController.ts
+++ b/src/controllers/balanceController.ts
@@ -213,7 +213,7 @@ export const initiateTopUp = async (req: AuthenticatedRequest, res: Response): P
           amount: topUpAmount,
           description: `ბალანსის შევსება - ${topUpAmount} ლარი`,
           callbackUrl: `${baseUrl}/api/balance/flitt/callback`,
-          responseUrl: `${baseUrl}/dashboard/balance?payment=success`
+          responseUrl: `${baseUrl}/en/dashboard/balance?payment=success`
         });
 
         const orderResult = await flittService.createOrder({
@@ -221,7 +221,7 @@ export const initiateTopUp = async (req: AuthenticatedRequest, res: Response): P
           amount: topUpAmount,
           description: `ბალანსის შევსება - ${topUpAmount} ლარი`,
           callbackUrl: `${baseUrl}/api/balance/flitt/callback`,
-          responseUrl: `${baseUrl}/dashboard/balance?payment=success`
+          responseUrl: `${baseUrl}/en/dashboard/balance?payment=success`
         });
 
         console.log('🔄 Flitt order result:', orderResult);
@@ -294,8 +294,8 @@ export const initiateTopUp = async (req: AuthenticatedRequest, res: Response): P
           currency: 'GEL',
           description: `ბალანსის შევსება - ${topUpAmount} ლარი`,
           callbackUrl: `${baseUrl}/api/balance/bog/callback`,
-          successUrl: `${baseUrl}/dashboard/balance?payment=success`,
-          failUrl: `${baseUrl}/dashboard/balance?payment=failed`,
+          successUrl: `${baseUrl}/en/dashboard/balance?payment=success`,
+          failUrl: `${baseUrl}/en/dashboard/balance?payment=failed`,
           paymentMethods: ['card'],  // Only card payments for now
           ttl: 15,
           buyer: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed post-payment redirects for Flitt and BOG so users return to the English dashboard Balance page after success or failure.
  - Ensures URLs include payment=success or payment=fail on the English path, avoiding redirects to non-localized pages.
  - Improves consistency and clarity of the payment flow for English-language users without altering other behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->